### PR TITLE
Fix sibling regeneration timing with promises

### DIFF
--- a/chat/templates/chat/index.html
+++ b/chat/templates/chat/index.html
@@ -803,23 +803,14 @@
                                         const newSiblingId = siblingData.new_message_id;
 
                                         // Refresh chat display to show the new empty sibling
-                                        const activeChatListItem = document.querySelector('.chat-item.bg-blue-600');
-                                        if (activeChatListItem) {
-                                            activeChatListItem.click(); // This re-fetches and re-renders
-                                        } else if (currentChatId) { // Fallback
-                                            const targetChatLink = document.querySelector(`.chat-link[data-chat-id="${currentChatId}"]`);
-                                            if (targetChatLink) targetChatLink.closest('.chat-item')?.click();
-                                        }
-                                        
-                                        // Wait for DOM update after re-render
-                                        setTimeout(() => {
+                                        refreshActiveChat().then(() => {
                                             const newSiblingElementProse = chatMessagesContainerEl.querySelector(`[data-message-id="${newSiblingId}"] .prose`);
                                             if (newSiblingElementProse) {
                                                 currentAssistantMessageId = newSiblingId;
                                                 currentAssistantMessageContentEl = newSiblingElementProse;
                                                 currentAssistantMessageContentEl.dataset.rawContent = ""; // Ensure it's empty
                                                 currentAssistantMessageContentEl.innerHTML = "";
-                                                
+
                                                 chatSocket.send(JSON.stringify({
                                                     type: 'generate_into_empty_message',
                                                     target_message_id: newSiblingId,
@@ -830,7 +821,7 @@
                                                 alert("Error preparing for generation. UI might be out of sync.");
                                                 unlockGlobalUIAfterGenerationEnd(); // Unlock UI
                                             }
-                                        }, 300); // Adjusted timeout, might need tuning
+                                        });
                                     } else {
                                         alert('Error creating sibling message: ' + (siblingData.error || 'Unknown error'));
                                         unlockGlobalUIAfterGenerationEnd(); // Unlock UI
@@ -1055,16 +1046,7 @@
                             const newlyCreatedSiblingId = siblingData.new_message_id;
 
                             // Refresh chat display to show the new empty sibling
-                            const activeChatListItem = document.querySelector('.chat-item.bg-blue-600');
-                            if (activeChatListItem) {
-                                activeChatListItem.click(); // This re-fetches and re-renders
-                            } else if (currentChatId) { // Fallback
-                                const targetChatLink = document.querySelector(`.chat-link[data-chat-id="${currentChatId}"]`);
-                                if (targetChatLink) targetChatLink.closest('.chat-item')?.click();
-                            }
-                            
-                            // Wait for DOM update after re-render and then ensure WebSocket is open
-                            setTimeout(() => {
+                            refreshActiveChat().then(() => {
                                 const newSiblingElementProse = chatMessagesContainerEl.querySelector(`[data-message-id="${newlyCreatedSiblingId}"] .prose`);
                                 if (!newSiblingElementProse) {
                                     console.error("Could not find new sibling element .prose in DOM after refresh for regeneration.");
@@ -1103,7 +1085,7 @@
                                 }
                                 attemptSendGenerate(); // Start polling
 
-                            }, 150); // Initial short delay for DOM to update after click()
+                            });
                         } else {
                             alert('Error creating sibling message for regeneration: ' + (siblingData.error || 'Unknown error'));
                             unlockGlobalUIAfterGenerationEnd(); // Unlock UI on error
@@ -1353,6 +1335,47 @@
                 });
             }
 
+            // Fetch chat details and render them. Returns a promise that resolves
+            // once the DOM has been updated and WebSocket reconnected.
+            function fetchAndRenderChat(chatId) {
+                return fetch(`/api/chat/${chatId}/`)
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error(`HTTP error! status: ${response.status}`);
+                        }
+                        return response.json();
+                    })
+                    .then(data => {
+                        if (data.ai_model_used_id) {
+                            chatModelSelectEl.value = data.ai_model_used_id;
+                        } else {
+                            if (chatModelSelectEl.options.length > 0) {
+                                chatModelSelectEl.selectedIndex = 0;
+                            }
+                        }
+                        chatModelTempEl.textContent = data.temperature || 'N/A';
+                        currentChatRootMessageId = data.root_message_id;
+
+                        chatMessagesContainerEl.innerHTML = '';
+                        if (data.messages && data.messages.length > 0) {
+                            let messageCounter = { value: 0 };
+                            renderMessageTree(data.messages, chatMessagesContainerEl, messageCounter, currentChatRootMessageId);
+                        } else {
+                            chatMessagesContainerEl.innerHTML = '<p class="text-gray-500 p-4">No messages in this chat yet.</p>';
+                        }
+                        chatMessagesContainerEl.scrollTop = chatMessagesContainerEl.scrollHeight;
+
+                        if (chatId) {
+                            connectWebSocket(chatId);
+                        }
+                    });
+            }
+
+            function refreshActiveChat() {
+                if (!currentChatId) return Promise.resolve();
+                return fetchAndRenderChat(currentChatId);
+            }
+
 
             chatItems.forEach(item => {
                 item.addEventListener('click', function (event) {
@@ -1381,45 +1404,10 @@
                     }
                     currentActiveChatLi = this;
 
-                    fetch(`/api/chat/${currentChatId}/`)
-                        .then(response => {
-                            if (!response.ok) {
-                                throw new Error(`HTTP error! status: ${response.status}`);
-                            }
-                            return response.json();
-                        })
-                        .then(data => {
-                            // console.log("Chat details:", data);
-                            // Set the selected model in the dropdown
-                            if (data.ai_model_used_id) {
-                                chatModelSelectEl.value = data.ai_model_used_id;
-                            } else {
-                                // If no specific model ID, try to select the first option or handle as needed
-                                if (chatModelSelectEl.options.length > 0) {
-                                    chatModelSelectEl.selectedIndex = 0;
-                                }
-                            }
-                            chatModelTempEl.textContent = data.temperature || 'N/A';
-                            currentChatRootMessageId = data.root_message_id; // Store root message ID
-                            
-                            chatMessagesContainerEl.innerHTML = ''; // Clear previous messages
-                            if (data.messages && data.messages.length > 0) {
-                                let messageCounter = { value: 0 };
-                                renderMessageTree(data.messages, chatMessagesContainerEl, messageCounter, currentChatRootMessageId); // Pass currentChatRootMessageId
-                            } else {
-                                chatMessagesContainerEl.innerHTML = '<p class="text-gray-500 p-4">No messages in this chat yet.</p>';
-                            }
-                            chatMessagesContainerEl.scrollTop = chatMessagesContainerEl.scrollHeight;
-                            
-                            // Connect WebSocket for the newly selected/loaded chat
-                            if (currentChatId) { // Ensure currentChatId is valid
-                                connectWebSocket(currentChatId);
-                                // requestCostEstimation(); // Moved to onopen for initial load
-                            }
-                        })
+                    fetchAndRenderChat(currentChatId)
                         .catch(error => {
                             console.error('Error fetching chat details:', error);
-                            if (chatSocket && chatSocket.readyState === WebSocket.OPEN) { 
+                            if (chatSocket && chatSocket.readyState === WebSocket.OPEN) {
                                 chatSocket.close();
                             }
                             chatMessagesContainerEl.innerHTML = '<p class="text-red-400 p-4">Error loading chat. Please try again.</p>';


### PR DESCRIPTION
## Summary
- avoid timeouts when waiting for sibling nodes
- refresh chat with new `fetchAndRenderChat` promise
- wait for refresh before sending regenerate requests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840653c6e8c83339608319350dcddb6