### PR TITLE
Add fenced code block support in chat markdown

### DIFF
--- a/chat/templates/chat/index.html
+++ b/chat/templates/chat/index.html
@@ -324,6 +324,8 @@
             html = html.replace(/(\*|_)(.*?)\1/g, '<em>$2</em>');
             // Strikethrough ~~text~~
             html = html.replace(/~~(.*?)~~/g, '<del>$1</del>');
+            // Code block ```text```
+            html = html.replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>');
             return html;
         }
 


### PR DESCRIPTION
## Summary
- support fenced code blocks in `renderMarkdownSafe`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684071ac2ee0833395c16aaa22548acf