### PR TITLE
Add delete-children feature

### DIFF
--- a/chat/templates/chat/index.html
+++ b/chat/templates/chat/index.html
@@ -1280,6 +1280,51 @@
                 iconsDiv.appendChild(copyButton);
                 iconsDiv.appendChild(editButton);
 
+                const deleteChildrenButton = document.createElement('button');
+                deleteChildrenButton.innerHTML = '🧹'; // Unicode for Broom
+                deleteChildrenButton.title = 'Delete children';
+                deleteChildrenButton.classList.add('text-xs', 'hover:text-gray-300', 'focus:outline-none');
+                deleteChildrenButton.addEventListener('click', function() {
+                    const messageIdToPrune = messageDiv.dataset.messageId;
+                    if (!messageIdToPrune || !currentChatId) {
+                        alert('Cannot delete children: ID or Chat context missing.');
+                        return;
+                    }
+                    if (window.confirm('Delete all child messages of this message? This action cannot be undone.')) {
+                        fetch(`/api/chat/${currentChatId}/message/${messageIdToPrune}/delete_children/`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': '{{ csrf_token }}'
+                            },
+                        })
+                        .then(response => {
+                            if (!response.ok) {
+                                return response.json().then(err => { throw new Error(err.error || `HTTP error! status: ${response.status}`) });
+                            }
+                            return response.json();
+                        })
+                        .then(data => {
+                            console.log('Children deletion successful:', data.message);
+                            const activeChatListItem = document.querySelector('.chat-item.bg-blue-600');
+                            if (activeChatListItem) {
+                                activeChatListItem.click();
+                            } else if (currentChatId) {
+                                const targetChatLink = document.querySelector(`.chat-link[data-chat-id="${currentChatId}"]`);
+                                if (targetChatLink) {
+                                    const targetChatItem = targetChatLink.closest('.chat-item');
+                                    if (targetChatItem) targetChatItem.click();
+                                }
+                            }
+                        })
+                        .catch(error => {
+                            console.error('Error deleting children:', error);
+                            alert('Error deleting children: ' + error.message);
+                        });
+                    }
+                });
+                iconsDiv.appendChild(deleteChildrenButton);
+
                 // Conditionally add the "Clean Remove" button if not the root message
                 if (msg.id !== chatRootMessageId) {
                     const cleanRemoveButton = document.createElement('button');

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
     path('api/chat/<int:chat_id>/message/<int:message_id>/update_role/', views.update_message_role_api, name='update_message_role_api'),
     path('api/chat/<int:chat_id>/message/<int:message_id>/delete/', views.delete_message_api, name='delete_message_api'),
     path('api/chat/<int:chat_id>/message/<int:message_id>/clean_remove/', views.clean_remove_message_api, name='clean_remove_message_api'),
+    path('api/chat/<int:chat_id>/message/<int:message_id>/delete_children/', views.delete_children_message_api, name='delete_children_message_api'),
     path('api/chat/<int:chat_id>/message/<int:source_message_id>/add_sibling/', views.add_sibling_message_api, name='add_sibling_message_api'),
     path('api/chat/<int:chat_id>/set_active_child/', views.set_active_child_api, name='set_active_child_api'),
     path('api/chat/<int:chat_id>/message/<int:parent_message_id>/add_child_message/', views.add_child_message_api, name='add_child_message_api'), # New route

--- a/chat/views.py
+++ b/chat/views.py
@@ -765,6 +765,24 @@ def clean_remove_message_api(request, chat_id, message_id):
 
 @login_required
 @require_POST
+@transaction.atomic
+def delete_children_message_api(request, chat_id, message_id):
+    """Delete all children of a message while keeping the message itself."""
+    message_obj = get_object_or_404(Message, id=message_id, chat_id=chat_id, chat__user=request.user)
+
+    # Remove all direct children; cascades will delete deeper descendants
+    message_obj.children.all().delete()
+
+    # Clear any active child reference
+    if message_obj.active_child:
+        message_obj.active_child = None
+        message_obj.save(update_fields=['active_child'])
+
+    return JsonResponse({'status': 'success', 'message': 'Child messages deleted.'})
+
+
+@login_required
+@require_POST
 def add_sibling_message_api(request, chat_id, source_message_id):
     source_message = get_object_or_404(Message, id=source_message_id, chat_id=chat_id, chat__user=request.user)
     # This view might not always receive a JSON body, as per the frontend JS, it's a POST without a body.


### PR DESCRIPTION
## Summary
- create delete_children_message_api view
- expose endpoint in urls
- add delete children icon and action in chat UI

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68408f9886b88333807b62b9c4a0f3cd